### PR TITLE
Added download button for development version of PearAI to contributors page

### DIFF
--- a/docs/contributors.md
+++ b/docs/contributors.md
@@ -14,6 +14,13 @@ We welcome contributions from the community! Whether you're fixing a bug, improv
 
 **Please review our coding [Contributing Guide](https://github.com/trypear/pearai-app/blob/main/CONTRIBUTING.md) to set up your coding environment.** For any questions, join the [PearAI Discord](https://discord.gg/7QMraJUsQt)!
 
+### Download the Development Version of PearAI
+
+To run PearAI in development mode, you need to download the unnotarized version of the app since the notarized version cannot run in debug mode.
+
+[**Download Development Version of PearAI**](https://drive.google.com/drive/u/0/folders/1lxKEZG2iqee7L5PCPLwCSjcmQhDknJCW)
+
+
 For a complete onboarding to being a PearAI contributor, see this [onboarding presentation](https://docs.google.com/presentation/d/1zR9-7DTlb2PcsnapryZw8jHSkLTs9JxeXth4nyeemAQ/edit).
 
 For quick access to all links regarding PearAI, save this [Master Doc](https://docs.google.com/document/d/14jusGNbGRPT8X6GgEDbP1iab5q4X7_y-eFXK7Ky57IQ/edit#heading=h.4w42owbrw5n8).

--- a/docs/contributors.md
+++ b/docs/contributors.md
@@ -14,7 +14,7 @@ We welcome contributions from the community! Whether you're fixing a bug, improv
 
 **Please review our coding [Contributing Guide](https://github.com/trypear/pearai-app/blob/main/CONTRIBUTING.md) to set up your coding environment.** For any questions, join the [PearAI Discord](https://discord.gg/7QMraJUsQt)!
 
-### Download the Development Version of PearAI
+### For Mac users: Download the Development Version of PearAI
 
 To run PearAI in development mode, you need to download the unnotarized version of the app since the notarized version cannot run in debug mode.
 


### PR DESCRIPTION
Add Download Button for Development Version of PearAI

#### FIX ISSUE
Closes [trypear/pear-landing-page#276](https://github.com/trypear/pear-landing-page/issues/276)


#### Description
This PR adds a download button for the unnotarized development version of PearAI to the contributors page. This change helps contributors easily access the necessary version of the app for development purposes, as the notarized version cannot run in debug mode.

#### Changes Made
- Added a new section to the contributors page with a download button.
- Included a link to the Google Drive folder containing the development version of PearAI.

#### Related Issue
Closes [trypear/pear-landing-page#276](https://github.com/trypear/pear-landing-page/issues/276)

