### PR TITLE
Fixed the videos to be responsive on mobile

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -16,10 +16,12 @@ keywords: [quickstart, start, install, vscode, jetbrains]
 
    :::
 
-   <video width="400" controls>
+  <div style={{ position: 'relative', paddingBottom: '56.25%', height: 0, overflow: 'hidden', marginBottom: '1rem' }}>
+   <video style={{ position: 'absolute', top: 0, left: 0, width: '100%', height: '100%' }} controls>
       <source src="/docs/videos/pearai-onboard-login.webm" type="video/webm" />
       Your browser does not support the video tag.
    </video>
+  </div>
 
 3. Optional: put PearAI in your path so you can open within directories with `pearai .`
 
@@ -28,16 +30,21 @@ keywords: [quickstart, start, install, vscode, jetbrains]
 4. You're now ready to start prompting! Try out the 2 core features below:
 
    1. `CMD+I` (Inline code editing)
-      <video width="400" controls>
-         <source src="/docs/videos/cmd+i-documentation.webm" type="video/webm" />
-         Your browser does not support the video tag.
-      </video>
+
+   <div style={{ position: 'relative', paddingBottom: '56.25%', height: 0, overflow: 'hidden', marginBottom: '1rem' }}>
+   <video style={{ position: 'absolute', top: 0, left: 0, width: '100%', height: '100%' }} controls>
+      <source src="/docs/videos/cmd+i-documentation.webm" type="video/webm" />
+      Your browser does not support the video tag.
+   </video>
+   </div>
 
    2. `CMD+L` (PearAI chat)
-      <video width="400" controls>
-         <source src="/docs/videos/cmd+l-documentation.webm" type="video/webm" />
-         Your browser does not support the video tag.
-      </video>
+   <div style={{ position: 'relative', paddingBottom: '56.25%', height: 0, overflow: 'hidden', marginBottom: '1rem' }}>
+   <video style={{ position: 'absolute', top: 0, left: 0, width: '100%', height: '100%' }} controls>
+      <source src="/docs/videos/cmd+l-documentation.webm" type="video/webm" />
+      Your browser does not support the video tag.
+   </video>
+   </div>
 
    
    


### PR DESCRIPTION
There isn't an issue attached for this problem but i saw it as i was scrolling the docs page on my phone 

This is how it looked like before:
![issuedocs](https://github.com/user-attachments/assets/ccfb7b75-51aa-443c-8fc6-a7cf17d98e3c)

This is how it looks like now:
![image](https://github.com/user-attachments/assets/9276084f-bc9e-4937-922e-661a9592fbc5)

It was also breaking the navbar. but thats already fixed with this changes