### PR TITLE
feat: implement dynamic baseUrl for flexible deployments previews

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -18,7 +18,7 @@ const config = {
   url: "https://trypear.ai",
   // Set the /<baseUrl>/ pathname under which your site is served
   // For GitHub pages deployment, it is often '/<projectName>/'
-  baseUrl: "/docs/",
+  baseUrl: process.env.BASE_URL || '/',
 
   // GitHub pages deployment config.
   // If you aren't using GitHub pages, you don't need these.


### PR DESCRIPTION
# Implement Dynamic baseUrl for Flexible Deployments

This PR introduces a dynamic `baseUrl` configuration for Docusaurus, enabling flexible deployments and improving our ability to verify changes in preview environments.

## Problem

Previously, we were unable to effectively test PR changes in preview deployments. Setting the `baseUrl` to '/docs/' caused Docusaurus assets and CSS to break in these preview environments.

## Solution

Implemented a dynamic `baseUrl` configuration that adapts to different deployment environments:
- For production: `baseUrl` is set to '/docs/'
- For preview deployments: `baseUrl` defaults to '/'

This approach allows us to:
1. Maintain the correct configuration for our production site at `abc.com/docs`
2. Properly render and test changes in preview deployments

## Environment Variable Setup

For production deployments only, add the following environment variable:

```
BASE_URL=/docs/
```

**Important:** Do not add this environment variable for preview deployments. The absence of this variable will default `baseUrl` to '/', ensuring correct functionality in preview environments.


**Please review and test this change thoroughly in both preview and production environments.**